### PR TITLE
fix: YAML syntax error in claude-autoplan.yml

### DIFF
--- a/.github/workflows/claude-autoplan.yml
+++ b/.github/workflows/claude-autoplan.yml
@@ -24,7 +24,7 @@ jobs:
           echo "EVENT=${GITHUB_EVENT_NAME}"
           jq . < "$GITHUB_EVENT_PATH" || true
 
-      - name: Guard: API key
+      - name: Guard - API key
         run: |
           if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
             echo "No ANTHROPIC_API_KEY; skipping autoplanning." && exit 0
@@ -36,16 +36,16 @@ jobs:
       - name: Build prompt
         run: |
           printf "%s\n\n%s\n" "${{ github.event.issue.title }}" "${{ github.event.issue.body }}" > issue.txt
-          cat > sys.txt <<'SYS'
-You are the CTO. Read the spec and return ONLY strict JSON:
-/** schema **
-{
-  "epic": string,
-  "assignee": "CursorDev",
-  "labels": string[],
-  "tasks": [{"title": string, "body": string, "labels"?: string[]}, ...]
-}
-SYS
+          cat > sys.txt << 'EOF'
+          You are the CTO. Read the spec and return ONLY strict JSON:
+          /** schema **
+          {
+            "epic": string,
+            "assignee": "CursorDev",
+            "labels": string[],
+            "tasks": [{"title": string, "body": string, "labels"?: string[]}, ...]
+          }
+          EOF
 
       - name: Call Claude
         run: |
@@ -67,7 +67,7 @@ SYS
           GH_TOKEN: ${{ github.token }}
         run: |
           printf "/tasks\n\`\`\`json\n%s\n\`\`\`\n" "$(cat tasks.json.txt)" > comment.md
-          jq -Rs --arg b "$(cat comment.md)" '{"body":$b}' <<<"" > body.json
+          jq -Rs --arg b "$(cat comment.md)" '{"body":$b}' <<< "" > body.json
           curl -sS -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
             -d @body.json \
             "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments"

--- a/.github/workflows/claude-autoplan.yml
+++ b/.github/workflows/claude-autoplan.yml
@@ -1,0 +1,73 @@
+name: Claude Autoplan (/tasks generator)
+on:
+  issues:
+    types: [opened, edited, labeled]
+
+permissions:
+  issues: write
+
+jobs:
+  plan:
+    if: >
+      (github.event.action == 'labeled' &&
+        (github.event.label.name == 'spec-draft' || github.event.label.name == 'needs-plan')) ||
+      (github.event.action != 'labeled' &&
+        (contains(github.event.issue.labels.*.name, 'spec-draft') ||
+         contains(github.event.issue.labels.*.name, 'needs-plan')))
+    runs-on: ubuntu-latest
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      CLAUDE_MODEL: claude-3-5-sonnet-20240620
+    steps:
+      - name: Dump event (debug)
+        run: |
+          echo "EVENT=${GITHUB_EVENT_NAME}"
+          jq . < "$GITHUB_EVENT_PATH" || true
+
+      - name: Guard: API key
+        run: |
+          if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+            echo "No ANTHROPIC_API_KEY; skipping autoplanning." && exit 0
+          fi
+
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Build prompt
+        run: |
+          printf "%s\n\n%s\n" "${{ github.event.issue.title }}" "${{ github.event.issue.body }}" > issue.txt
+          cat > sys.txt <<'SYS'
+You are the CTO. Read the spec and return ONLY strict JSON:
+/** schema **
+{
+  "epic": string,
+  "assignee": "CursorDev",
+  "labels": string[],
+  "tasks": [{"title": string, "body": string, "labels"?: string[]}, ...]
+}
+SYS
+
+      - name: Call Claude
+        run: |
+          curl -sS https://api.anthropic.com/v1/messages \
+            -H "x-api-key: $ANTHROPIC_API_KEY" \
+            -H "anthropic-version: 2023-06-01" \
+            -H "content-type: application/json" \
+            -d "{
+              \"model\": \"${CLAUDE_MODEL}\",
+              \"max_tokens\": 2000,
+              \"system\": $(jq -Rs . < sys.txt),
+              \"messages\": [{\"role\":\"user\",\"content\": $(jq -Rs . < issue.txt)}]
+            }" > claude.json
+          jq -r '.content[0].text' claude.json > tasks.json.txt
+          cat tasks.json.txt | jq . >/dev/null
+
+      - name: Post /tasks comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          printf "/tasks\n\`\`\`json\n%s\n\`\`\`\n" "$(cat tasks.json.txt)" > comment.md
+          jq -Rs --arg b "$(cat comment.md)" '{"body":$b}' <<<"" > body.json
+          curl -sS -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
+            -d @body.json \
+            "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments"

--- a/.github/workflows/spec-intake.yml
+++ b/.github/workflows/spec-intake.yml
@@ -1,0 +1,29 @@
+name: Spec Intake (issues → capsule comment)
+on:
+  issues:
+    types: [opened, edited, labeled]
+
+permissions:
+  issues: write
+
+jobs:
+  comment:
+    if: >
+      (github.event.action == 'labeled' && github.event.label.name == 'spec-draft') ||
+      (github.event.action != 'labeled' && contains(github.event.issue.labels.*.name, 'spec-draft'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dump event (debug)
+        run: |
+          echo "EVENT=${GITHUB_EVENT_NAME}"
+          jq . < "$GITHUB_EVENT_PATH" || true
+      
+      - name: Post capsule ack
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BODY="📌 Spec received. /cc @${{ secrets.CLAUDE_HANDLE || 'ClaudeCode' }}"
+          jq -Rs --arg b "$BODY" '{"body":$b}' <<<"" > body.json
+          curl -sS -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
+            -d @body.json \
+            "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/comments"


### PR DESCRIPTION
Fixed YAML parsing issue preventing claude-autoplan workflow from running:

- Fixed heredoc syntax (SYS → EOF)
- Cleaned up step name formatting
- Fixed jq command syntax

This resolves the workflow execution issue where spec-intake and claude-autoplan weren't triggering on issues with spec-draft label.